### PR TITLE
fixed permission

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -20,7 +20,10 @@
     "default_title": "__MSG_browserActionTitle__",
     "default_popup": "pages/popup.html"
   },
-  "permissions": ["clipboardWrite"],
+  "permissions": [
+    "clipboardWrite",
+    "*://www.lgtm.app/*"
+  ],
   "content_scripts": [
     {
       "matches": ["https://github.com/*/pull/*"],


### PR DESCRIPTION
Only Firefox returns an error.

> TypeError: NetworkError when attempting to fetch resource

It was fixed by adding the URL of LGTM.app to permissions in `manifest.json`.